### PR TITLE
Fix type in log4j2.properties

### DIFF
--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -11,7 +11,7 @@ appenders = stdout, stderr, file, performance
  
 appender.stdout.type = Console
 appender.stdout.name = STDOUT
-appender.stderr.target = SYSTEM_OUT
+appender.stdout.target = SYSTEM_OUT
 appender.stdout.filters = levelRange
 appender.stdout.filter.levelRange.type = LevelRangeFilter
 appender.stdout.filter.levelRange.minLevel = info


### PR DESCRIPTION
This example was really helpful to me, but I noticed a typo in the `appender.stdout` section.